### PR TITLE
fix typo in nologin parametre

### DIFF
--- a/common/libnetmagis.tcl
+++ b/common/libnetmagis.tcl
@@ -1059,7 +1059,7 @@ snit::type ::netmagis {
 	# for users specified in ROOT pattern.
 	#
 
-	set ftest [get-local-conf "nologin"]
+	set ftest [get-local-conf "nologinfile"]
 	set rootusers [get-local-conf "rootusers"]
 	if {! [catch [lindex $rootusers 0]]} then {
 	    $self error "Invalid 'rootusers' configuration parameter"


### PR DESCRIPTION
in sample config file, nologin parametre is "nologinfile"
however, in libnetmagis.tcl , it's spelled "nologin".

Since we can't change installed config files all around the world,
it's better to change libnetmagis.tcl to match the parametre name
in the config file.
