### PR TITLE
Fix the CAS ticket regex

### DIFF
--- a/www/cgi/login
+++ b/www/cgi/login
@@ -136,7 +136,7 @@ proc welcome-user {dbfd login casticket} {
 # CAS authentication
 ##############################################################################
 
-d cgi-register {ticket ^ST-[-A-Za-z0-9]+$} {
+d cgi-register {ticket ^ST-.{0,256}$} {
     {ticket	1 1}
 } {
     global conf


### PR DESCRIPTION
Too strict, it is refusing the dot character for example.