### PR TITLE
Adding support for “protect:” keyword on Juniper devices

### DIFF
--- a/topo/src/parse-juniper.tcl
+++ b/topo/src/parse-juniper.tcl
@@ -305,7 +305,9 @@ proc juniper-parse-list {kwtab conf tab idx} {
 	    juniper-debug "kw = <$kw>"
 	}
 
-	if {[string equal $kw "inactive:"]} then {
+	if {[string equal $kw "protect:"]} then {
+	    set last 0
+	} elseif {[string equal $kw "inactive:"]} then {
 	    set inactive 1
 	    set last 0
 	} else {


### PR DESCRIPTION
This change allow the use of the `protect:` keyword in [Juniper configurations](https://www.juniper.net/techpubs/en_US/junos13.3/topics/task/configuration/junos-cli-configuration-protecting.html). It has no impact on the configuration meaning, it forbids any modification within the protected block.